### PR TITLE
Setup env variables.

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -1,0 +1,2 @@
+SECRET_KEY= # SECRET_KEY
+DEBUG= #true for development dont sent in production

--- a/djangomomoapi/settings.py
+++ b/djangomomoapi/settings.py
@@ -12,6 +12,9 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 
 import os
 
+from dotenv import load_dotenv
+
+load_dotenv()
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -20,10 +23,10 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'ld0%x$9gjq3c#05d5*#0o*e%kdi&@d02(hcjs+hrahs38*6p%('
+SECRET_KEY = os.getenv('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.getenv('DEBUG')
 
 ALLOWED_HOSTS = []
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ keyring==21.1.0
 pkginfo==1.5.0.1
 pycodestyle==2.5.0
 Pygments==2.5.2
+python-dotenv==0.11.0
 pytz==2019.3
 readme-renderer==24.0
 requests==2.22.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ README = (HERE / "README.md").read_text()
 # This does all the work once called
 setup(
     name="django-momoapi",
-    version="1.0.0",
+    version="1.1.0",
     description="This is a Django package for the MTN MoMo API.",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# Set up env variable.

## Description

- Install python-dotenv.
- Move variables that should be secret or specific to an environment to .env.
- Create .env_example file.
 

## Motivation and Context
Some variables will have different values depending on the environment the application is running in. For example debug will be true in development but false in production. It would make sense to be able to change this without having to make changes to the code base.

Closes issue [#7](https://github.com/mwanjajoel/django-momoapi/issues/7)

## How Has This Been Tested?
To test this simply create .env following .env_example.
Try to run application have setting a value for each entry in the .env.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
